### PR TITLE
fixed notices

### DIFF
--- a/top-level-cats.php
+++ b/top-level-cats.php
@@ -337,10 +337,14 @@ class FV_Top_Level_Cats {
       
       if( isset($_POST['fv_top_level_cats_submit'] ) ) :
         $options = get_option( 'fv_top_level_cats', array() );
-
-        $options['category-allow'] = $_POST['post_category'];
+        if(isset($_POST['post_category'])){
+            $options['category-allow'] = $_POST['post_category'];
+        }
         $options['top-level-only'] = ( $_POST['top-level-only'] ) ? true : false;
-        $options['category-allow-enabled'] = ( $_POST['category-allow-enabled'] ) ? true : false;
+
+        if(isset($_POST['category-allow-enabled'])){
+            $options['category-allow-enabled'] = ( $_POST['category-allow-enabled'] ) ? true : false;
+        }
       
         update_option( 'fv_top_level_cats', $options );
 ?>


### PR DESCRIPTION
Currently when having WP Debung enabled and you save the settings you might get the following notices displayed:

```
Notice: Undefined index: 
post_category in /wp-content/plugins/fv-top-level-cats/top-level-cats.php on line 341

Notice: Undefined index: 
category-allow-enabled in /wp-content/plugins/fv-top-level-cats/top-level-cats.php on line 346
```

I simply added a check if those indexes are not set.

Result , no confusing notices :)